### PR TITLE
bump up action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -51,7 +51,7 @@ jobs:
     name: Test / ${{ matrix.toolchain.name }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -68,7 +68,7 @@ jobs:
     name: Test Combined
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust (stable)
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust (stable)
-        uses: actions-rust-lang/setup-rust-toolchain@v1.8.0
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Read MSRV from workspace manifest
         id: read_msrv


### PR DESCRIPTION
`actions/checkout@v4` is using node 20 and node 20 actions are deprecated
- https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Also updated `setup-rust-toolchain` to use v1 just for convenience